### PR TITLE
Game Update 14 + QOL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,13 @@
 /.ccls-cache/
 /.cache/
 compile_commands.json
+
+# CMake
+CMakeLists.txt
+cmake-build-debug/
+cmake-build-debug-visual-studio/
+
+# IDE
+.idea/
+.vs/
+.clwb/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -83,6 +83,21 @@
         "valarray": "cpp",
         "variant": "cpp",
         "queue": "cpp",
-        "stack": "cpp"
+        "stack": "cpp",
+        "bit": "cpp",
+        "charconv": "cpp",
+        "compare": "cpp",
+        "concepts": "cpp",
+        "format": "cpp",
+        "optional": "cpp",
+        "stop_token": "cpp",
+        "coroutine": "cpp",
+        "scoped_allocator": "cpp",
+        "*.inc": "cpp",
+        "*.def": "cpp",
+        "*.rh": "cpp",
+        "any": "cpp",
+        "cfenv": "cpp",
+        "cinttypes": "cpp"
     }
 }

--- a/README.md
+++ b/README.md
@@ -137,6 +137,20 @@ For resources it is heavily recommended to use the Anno 1800/data folder.
 You need Bazel, Visual Studio 2019 and that _should_ be it.  
 You can checkout `azure-pipelines.yml` and see how it's done there.
 
+easy steps to sucess:
+  - Install Visual Studio 2019 (community version is fine + C++ tools)
+  - Install Bazel (could be a rabbit hole but if unsure use the recommendet way for your system)
+  - _optional_ fork this repo
+  - clone this repo (make sure you use the most recent branch/tag) into a workingdir
+  - open the folder in Visual Studio 2019
+  - _optiona_ make changes
+  - open a command prompt (admin) & navigate to the workingdir
+  - If you have installed another version of Visual Studio as well:
+    - ```set BAZEL_VC=C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC```
+    - this will use the correct build tools (if your VS 2019 install dir differ, please adapt)
+  - use ```bazel build //libs/python35:python35.dll``` to build the .dll
+  - find the DLL in your workingdir \bazel-bin\libs\python35
+    
 If you want to work on new features for XML operations, you can use xmltest for testing. As that is using the same code as the actualy file loader.
 
 # Coming soon (maybe)

--- a/libs/anno-api/src/random_game_functions.cc
+++ b/libs/anno-api/src/random_game_functions.cc
@@ -82,7 +82,7 @@ bool FindAddresses()
 
         // Do a combined pre-search
         ADDRESSES[READ_FILE_FROM_CONTAINER] = {[](std::optional<std::string_view> game_file) {
-            // Game Update 13 
+            // Game Update 14 
             try {
                auto match = meow_hook::pattern("E8 ? ? ? ? 0F B6 D8 48 8D 4D C0", game_file)
                                 .count(1)

--- a/libs/external-file-loader/include/mod.h
+++ b/libs/external-file-loader/include/mod.h
@@ -6,6 +6,9 @@
 #include <vector>
 #include <cstring>
 
+
+#include "nlohmann/json.hpp"
+
 namespace fs = std::filesystem;
 
 #include "utf8.h"
@@ -42,12 +45,21 @@ class Mod
     Mod() = default;
     explicit Mod(const fs::path &root);
 
-    std::string Name() const;
-    bool        HasFile(const fs::path &file) const;
-    void        ForEachFile(std::function<void(const fs::path &, const fs::path &)>) const;
-    fs::path    Path() const;
+    std::string    ID() const;
+    std::string    GUID() const;
+    std::string    Name() const;
+    std::string    Version() const;
+    std::string    Info() const;
+    nlohmann::json InfoJSON() const;
+    bool           HasFile(const fs::path &file) const;
+    void           ForEachFile(std::function<void(const fs::path &, const fs::path &)>) const;
+    fs::path       Path() const;
+    void           ParseInfoJSON(const fs::path& file);
 
   private:
     fs::path                               root_path;
     std::unordered_map<fs::path, fs::path> file_mappings;
+    std::string                            modID;
+    std::string                            modGUID;
+    std::string                            modVer;
 };

--- a/libs/external-file-loader/include/mod_manager.h
+++ b/libs/external-file-loader/include/mod_manager.h
@@ -38,9 +38,12 @@ class ModManager
 
     static fs::path GetModsDirectory();
     static fs::path GetCacheDirectory();
+    static fs::path GetMetaDirectory();
     static fs::path GetDummyPath();
     static void     EnsureDummy();
-
+    static void     EnsureMeta();
+    
+    void                            DocumentMods();
     bool                            IsFileModded(const fs::path& path) const;
     const File&                     GetModdedFileInfo(const fs::path& path) const;
     void                            GameFilesReady();


### PR DESCRIPTION
Sorry for the combined PR but:
 - the current dev branch is out of sync of the current code base (last dev version misses the game update 14 changes)
 - QOL 1: mods folder is now optional in /My Documents/Anno 1800/mods (besides the user savegames)
 - QOL 2: mods are now documented in {mods_origin}/.meta/history.log this way mods can now be associated with save-games 

[history.log](https://github.com/xforce/anno1800-mod-loader/files/9484654/history.log)
