### PR TITLE
fix `<Include>` file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,25 @@ example:
 ```
 > This ModOp will replace the node under /Values/Standard/Name of the asset with GUID 1337 with:  "```<Name>ThisIsATestNameForGUID1337</Name>```"
 
+## Split XML Patch into Multiple Files
+
+You can split your XML patches into multiple files by using `Include` instructions.
+
+```xml
+<ModOps>
+    <!-- ModOps applied before the include -->
+    <Include File="even-more-modops.include.xml" />
+    <!-- ModOps applied after the include -->
+</ModOps>
+```
+
+`File` takes a file path relative to the XML file that does the include.
+
+XML files without a counterpart in the game are normally mistakes and lead to errors in the log.
+Use the extension `*.include.xml` to prevent that.
+
+Otherwise, included XML patches are handled the same way as normal XML patches. Nesting includes is supported.
+
 ## Tutorial: Adding a new zoom level
 
 Put this in a mod folder with the game path

--- a/libs/external-file-loader/include/mod_manager.h
+++ b/libs/external-file-loader/include/mod_manager.h
@@ -54,6 +54,7 @@ class ModManager
 
   private:
     bool IsPatchableFile(const fs::path& file) const;
+    bool IsIncludeFile(const fs::path& file) const;
     bool IsPythonStartScript(const fs::path& file) const;
     void CollectPatchableFiles();
     void StartWatchingFiles();

--- a/libs/external-file-loader/src/mod_manager.cc
+++ b/libs/external-file-loader/src/mod_manager.cc
@@ -430,9 +430,16 @@ void ModManager::GameFilesReady()
 
             auto game_file = ReadGameFile(game_path);
             if (game_file.empty()) {
-                for (auto& on_disk_file : on_disk_files) {
-                    spdlog::error("Failed to get original game file {} {}", game_path.string(),
-                                  on_disk_file.string());
+                if (!IsIncludeFile(game_path))
+                {
+                    for (auto& on_disk_file : on_disk_files) {
+                        spdlog::error("Failed to get original game file {} {}", game_path.string(),
+                                    on_disk_file.string());
+                    }    
+                }
+                else {
+                    // include files are not expected to have original counterparts,
+                    // but should follow normal patching procedure if they do
                 }
                 continue;
             }
@@ -635,6 +642,15 @@ bool ModManager::IsPatchableFile(const fs::path& file) const
     // Other files have to be replaced entirely
     const auto extension = file.extension();
     return extension == ".xml";
+}
+
+bool ModManager::IsIncludeFile(const fs::path& file) const
+{
+    if (!IsPatchableFile(file)) {
+        return false;
+    }
+    const auto secondaryExtension = file.stem().extension();
+    return secondaryExtension == ".include";
 }
 
 std::string ModManager::GetFileHash(const fs::path& path) const

--- a/libs/xml-operations/include/xml_operations.h
+++ b/libs/xml-operations/include/xml_operations.h
@@ -28,7 +28,8 @@ class XmlOperation
     static std::vector<XmlOperation> GetXmlOperations(std::shared_ptr<pugi::xml_document> doc,
                                                       std::string mod_name  = "",
                                                       fs::path    game_path = {},
-                                                      fs::path    mod_path  = {});
+                                                      fs::path    mod_path  = {},
+                                                      fs::path    doc_path  = {});
     static std::vector<XmlOperation> GetXmlOperationsFromFile(fs::path    path,
                                                               std::string mod_name  = "",
                                                               fs::path    game_path = {},

--- a/libs/xml-operations/src/xml_operations.cc
+++ b/libs/xml-operations/src/xml_operations.cc
@@ -464,7 +464,8 @@ std::vector<XmlOperation> XmlOperation::GetXmlOperationsFromFile(fs::path    pat
                       location.first, location.second, parse_result.description());
         return {};
     }
-    return GetXmlOperations(doc, mod_name, game_path, mod_path, path.parent_path());
+    const auto doc_path = path.lexically_normal().parent_path();
+    return GetXmlOperations(doc, mod_name, game_path, mod_path, doc_path);
 }
 
 void MergeProperties(pugi::xml_node game_node, pugi::xml_node patching_node)

--- a/libs/xml-operations/src/xml_operations.cc
+++ b/libs/xml-operations/src/xml_operations.cc
@@ -403,7 +403,7 @@ void XmlOperation::Apply(std::shared_ptr<pugi::xml_document> doc)
 
 std::vector<XmlOperation> XmlOperation::GetXmlOperations(std::shared_ptr<pugi::xml_document> doc,
                                                          std::string mod_name, fs::path game_path,
-                                                         fs::path mod_path)
+                                                         fs::path mod_path, fs::path doc_path)
 {
 #ifndef _WIN32
     auto stricmp = [](auto a, auto b) { return strcasecmp(a, b); };
@@ -437,7 +437,7 @@ std::vector<XmlOperation> XmlOperation::GetXmlOperations(std::shared_ptr<pugi::x
                 } else if (stricmp(node.name(), "Include") == 0) {
                     const auto file = GetXmlPropString(node, "File");
                     auto       include_ops =
-                        GetXmlOperationsFromFile(mod_path / file, mod_name, game_path, mod_path);
+                        GetXmlOperationsFromFile(doc_path / file, mod_name, game_path, mod_path);
                     mod_operations.insert(std::end(mod_operations), std::begin(include_ops),
                                           std::end(include_ops));
                 }
@@ -464,7 +464,7 @@ std::vector<XmlOperation> XmlOperation::GetXmlOperationsFromFile(fs::path    pat
                       location.first, location.second, parse_result.description());
         return {};
     }
-    return GetXmlOperations(doc, mod_name, game_path, mod_path);
+    return GetXmlOperations(doc, mod_name, game_path, mod_path, path.parent_path());
 }
 
 void MergeProperties(pugi::xml_node game_node, pugi::xml_node patching_node)

--- a/tests/xml/gen_tests.py
+++ b/tests/xml/gen_tests.py
@@ -15,13 +15,15 @@ def main():
                 for file in glob.glob(os.path.join(test_type_dir, "*.json")):
                     with open(file, "r") as json_file:
                         data = json.load(json_file)
+                    test_path = os.path.join("tests", "xml", test_type)
+                    folder = data.get('folder')
+                    if folder is not None:
+                        test_path = os.path.join(test_path, folder)
                     f.write("TEST_CASE(\"" + data['name'] + "\") {\n")
                     base_name = os.path.splitext(os.path.basename(file))[0]
-                    base_name_input = os.path.join(test_type,
+                    base_name_input = os.path.join(test_path,
                                                    base_name + "_input.xml")
-                    base_name_input = os.path.join("tests", "xml", test_type,
-                                                   base_name + "_input.xml")
-                    base_name_patch = os.path.join("tests", "xml", test_type,
+                    base_name_patch = os.path.join(test_path,
                                                    base_name + "_patch.xml")
                     f.write("TestRunner runner(\"%s\", \"%s\", \"%s\");\n" %
                             (os.path.join("tests", "xml", test_type).replace(

--- a/tests/xml/include/config/export/include_nested_nontrivial_input.xml
+++ b/tests/xml/include/config/export/include_nested_nontrivial_input.xml
@@ -1,0 +1,5 @@
+<Test>
+    <Node>
+        <Meow />
+    </Node>
+</Test>

--- a/tests/xml/include/config/export/include_nested_nontrivial_patch.xml
+++ b/tests/xml/include/config/export/include_nested_nontrivial_patch.xml
@@ -1,0 +1,3 @@
+<ModOps>
+    <Include File="../include_nested_input.xml" />
+</ModOps>

--- a/tests/xml/include/config/export/include_nontrivial_input.xml
+++ b/tests/xml/include/config/export/include_nontrivial_input.xml
@@ -1,0 +1,6 @@
+<ModOps>
+<ModOp Type="add" Path="/Test/Node">
+    <Cat>10</Cat>
+    <Cat2>10</Cat2>
+</ModOp>
+</ModOps>

--- a/tests/xml/include/config/export/include_nontrivial_path_input.xml
+++ b/tests/xml/include/config/export/include_nontrivial_path_input.xml
@@ -1,0 +1,5 @@
+<Test>
+    <Node>
+        <Meow />
+    </Node>
+</Test>

--- a/tests/xml/include/config/export/include_nontrivial_path_patch.xml
+++ b/tests/xml/include/config/export/include_nontrivial_path_patch.xml
@@ -1,0 +1,3 @@
+<ModOps>
+    <Include File="./include_nontrivial_input.xml" />
+</ModOps>

--- a/tests/xml/include/config/include_nested_input.xml
+++ b/tests/xml/include/config/include_nested_input.xml
@@ -1,0 +1,9 @@
+<ModOps>
+    <Include File="../include_input.xml" />
+    <ModOp Type="add" Path="/Test/Node">
+        <Cat3>5</Cat3>
+    </ModOp>
+    <ModOp Type="replace" Path="/Test/Node/Cat2">
+        <Cat2>5</Cat2>
+    </ModOp>
+</ModOps>

--- a/tests/xml/include/include_input_order.xml
+++ b/tests/xml/include/include_input_order.xml
@@ -1,0 +1,7 @@
+<ModOps>
+    <ModOp Type="replace" Path="/Test/Node[Cat='1']">
+        <Node>
+            <Cat>2</Cat>
+        </Node>
+    </ModOp>
+</ModOps>

--- a/tests/xml/include/include_nested_include.json
+++ b/tests/xml/include/include_nested_include.json
@@ -1,0 +1,9 @@
+{
+    "name": "Include nested within included file",
+    "expected": [
+        "/Test/Node/Meow",
+        "/Test/Node[Cat3='5']",
+        "/Test/Node[Cat='10']",
+        "/Test/Node[Cat2='5']"
+    ]
+}

--- a/tests/xml/include/include_nested_include_input.xml
+++ b/tests/xml/include/include_nested_include_input.xml
@@ -1,0 +1,5 @@
+<Test>
+    <Node>
+        <Meow />
+    </Node>
+</Test>

--- a/tests/xml/include/include_nested_include_patch.xml
+++ b/tests/xml/include/include_nested_include_patch.xml
@@ -1,0 +1,3 @@
+<ModOps>
+    <Include File="include_nested_input.xml" />
+</ModOps>

--- a/tests/xml/include/include_nested_input.xml
+++ b/tests/xml/include/include_nested_input.xml
@@ -1,0 +1,9 @@
+<ModOps>
+    <Include File="include_input.xml" />
+    <ModOp Type="add" Path="/Test/Node">
+        <Cat3>5</Cat3>
+    </ModOp>
+    <ModOp Type="replace" Path="/Test/Node/Cat2">
+        <Cat2>5</Cat2>
+    </ModOp>
+</ModOps>

--- a/tests/xml/include/include_nested_nontrivial.json
+++ b/tests/xml/include/include_nested_nontrivial.json
@@ -1,0 +1,10 @@
+{
+    "name": "Include nested with nontrivial path within included file",
+    "folder": "config/export",
+    "expected": [
+        "/Test/Node/Meow",
+        "/Test/Node[Cat3='5']",
+        "/Test/Node[Cat='10']",
+        "/Test/Node[Cat2='5']"
+    ]
+}

--- a/tests/xml/include/include_nontrivial_path.json
+++ b/tests/xml/include/include_nontrivial_path.json
@@ -1,0 +1,9 @@
+{
+    "name": "Include from non-trivial path",
+    "folder": "config/export",
+    "expected": [
+        "/Test/Node/Meow",
+        "/Test/Node[Cat='10']",
+        "/Test/Node[Cat2='10']"
+    ]
+}

--- a/tests/xml/include/include_order.json
+++ b/tests/xml/include/include_order.json
@@ -1,0 +1,6 @@
+{
+    "name": "Include with Correct Order",
+    "expected": [
+        "/Test/Node[Cat='3']"
+    ]
+}

--- a/tests/xml/include/include_order_input.xml
+++ b/tests/xml/include/include_order_input.xml
@@ -1,0 +1,5 @@
+<Test>
+    <Node>
+        <Meow />
+    </Node>
+</Test>

--- a/tests/xml/include/include_order_patch.xml
+++ b/tests/xml/include/include_order_patch.xml
@@ -1,0 +1,9 @@
+<ModOps>
+    <ModOp Type="add" Path="/Test/Node">
+        <Cat>1</Cat>
+    </ModOp>
+    <Include File="include_input_order.xml" />
+    <ModOp Type="replace" Path="/Test/Node/Cat['2']">
+        <Cat>3</Cat>
+    </ModOp>
+</ModOps>


### PR DESCRIPTION
Tests, xml-test and modloader all had different and partly behavior.

This changes the path to be always relative to the including XML.

Closes #113, Closes #164