### PR TITLE
New, order independent merge algorithm

### DIFF
--- a/libs/xml-operations/include/xml_operations.h
+++ b/libs/xml-operations/include/xml_operations.h
@@ -68,8 +68,23 @@ class XmlOperation
     {
         return node.attribute(prop_name.c_str()).as_string();
     }
+	
+	bool NodeHasPCDataChild(pugi::xml_node node);
+	
+	std::vector<pugi::xml_node> ChildrenVectorFromNode(pugi::xml_node node);
+	
+	void MergeOp(pugi::xml_node root_game_node, pugi::xml_node game_node,
+                        pugi::xml_node patching_node);
+						
+	pugi::xml_node FindNamedListItemRecursive(std::vector<pugi::xml_node> const& in_nodes, std::string name, bool find_pcdata_node);
+	
+    void MergeSiblings(pugi::xml_node root_game_node, pugi::xml_node game_node,
+                        pugi::xml_node patching_node);
+						
     void RecursiveMerge(pugi::xml_node root_game_node, pugi::xml_node game_node,
                         pugi::xml_node patching_node);
+						
+						
     void ReadPath(pugi::xml_node node, std::string guid = "", std::string temp = "");
     void ReadType(pugi::xml_node node, std::string mod_name, fs::path game_path, fs::path mod_path);
 

--- a/tests/xml/merge/merge_multi_node_content_3.json
+++ b/tests/xml/merge/merge_multi_node_content_3.json
@@ -1,0 +1,10 @@
+{
+    "name": "Multi node merge content nested skipping parent with same name",
+    "expected": [
+        "/Test/Node/FullSatisfactionDistance",
+        "/Test/Node/NoSatisfactionDistance",
+        "/Test/Node[FullSatisfactionDistance='60']",
+        "/Test/Node/NoSatisfactionDistance[NoSatisfactionDistance='100']",
+        "/Test/Node/SomeSatisfactionDistance[SomeSatisfactionDistance='100']"
+    ]
+}

--- a/tests/xml/merge/merge_multi_node_content_3_input.xml
+++ b/tests/xml/merge/merge_multi_node_content_3_input.xml
@@ -1,0 +1,13 @@
+<Test>
+    <Node>
+        <FullSatisfactionDistance>5</FullSatisfactionDistance>
+        <NoSatisfactionDistance>
+            <NoSatisfactionDistance>90</NoSatisfactionDistance>
+        </NoSatisfactionDistance>
+        <SomeSatisfactionDistance>
+            <SomeSatisfactionDistance>
+              10
+            </SomeSatisfactionDistance>
+        </SomeSatisfactionDistance>
+    </Node>
+</Test>

--- a/tests/xml/merge/merge_multi_node_content_3_patch.xml
+++ b/tests/xml/merge/merge_multi_node_content_3_patch.xml
@@ -1,0 +1,9 @@
+<ModOps>
+<ModOp Type="merge" Path="/Test/Node">
+    <FullSatisfactionDistance>60</FullSatisfactionDistance>
+    <NoSatisfactionDistance>100</NoSatisfactionDistance>
+    <SomeSatisfactionDistance>
+        <SomeSatisfactionDistance>100</SomeSatisfactionDistance>
+    </SomeSatisfactionDistance>
+</ModOp>
+</ModOps>

--- a/tests/xml/merge/merge_strange_shit_deep_access.json
+++ b/tests/xml/merge/merge_strange_shit_deep_access.json
@@ -1,0 +1,8 @@
+{
+    "name": "Merge strange shit with deep item access (yes ShutdownThreshold should stay 0.5)",
+    "expected": [
+        "//Values/Maintenance/Maintenances/Item[Product='1010017' and Amount='50000']",
+        "//Values/Maintenance/Maintenances/Item[Product='1010117' and NestedAmount/Amount='1500']",
+        "//Values/Maintenance/Maintenances/Item[Product='1010117' and NestedAmount/Amount='1500' and ShutdownThreshold='0.5']"
+    ]
+}

--- a/tests/xml/merge/merge_strange_shit_deep_access_input.xml
+++ b/tests/xml/merge/merge_strange_shit_deep_access_input.xml
@@ -1,0 +1,36 @@
+<AssetList>
+<Groups>
+<Group>
+<Assets>
+    <Asset>
+        <Template>PowerplantBuilding</Template>
+        <Values>
+            <Standard>
+                <GUID>100780</GUID>
+                <Name>electricity_02 (Oil Power Plant)</Name>
+                <IconFilename>data/ui/2kimages/main/3dicons/icon_electric_works_oil.png</IconFilename>
+                <ID>OilPowerPlant</ID>
+                <InfoDescription>10946</InfoDescription>
+            </Standard>
+            <Maintenance>
+                <Maintenances>
+                    <Item>
+                        <Product>1010017</Product>
+                        <Amount>400</Amount>
+                        <InactiveAmount>200</InactiveAmount>
+                    </Item>
+                    <Item>
+                        <Product>1010117</Product>
+                        <NestedAmount>
+                          <Amount>150</Amount>
+                        </NestedAmount>
+                        <ShutdownThreshold>0.5</ShutdownThreshold>
+                    </Item>
+                </Maintenances>
+            </Maintenance>
+        </Values>
+    </Asset>
+</Assets>
+</Group>
+</Group>
+</AssetList>

--- a/tests/xml/merge/merge_strange_shit_deep_access_patch.xml
+++ b/tests/xml/merge/merge_strange_shit_deep_access_patch.xml
@@ -1,0 +1,14 @@
+<ModOps>
+<ModOp Type="merge" GUID='100780' Path="/Values">
+            <Item>
+                <Product>1010017</Product>
+                <Amount>50000</Amount>
+                <InactiveAmount>30000</InactiveAmount>
+            </Item>
+            <Item>
+                <Product>1010117</Product>
+                <Amount>1500</Amount>
+                <ShutdownThreshold>1</ShutdownThreshold>
+            </Item>
+</ModOp>
+</ModOps>

--- a/tests/xml/merge/merge_strange_shit_unordered.json
+++ b/tests/xml/merge/merge_strange_shit_unordered.json
@@ -1,0 +1,7 @@
+{
+    "name": "Merge strange shit but unordered",
+    "expected": [
+        "//Values/Maintenance/Maintenances/Item[Product='1010017' and Amount='50000' and InactiveAmount='30000']",
+        "//Values/Maintenance/Maintenances/Item[Product='1010117' and ShutdownThreshold='1']"
+    ]
+}

--- a/tests/xml/merge/merge_strange_shit_unordered_input.xml
+++ b/tests/xml/merge/merge_strange_shit_unordered_input.xml
@@ -1,0 +1,34 @@
+<AssetList>
+<Groups>
+<Group>
+<Assets>
+    <Asset>
+        <Template>PowerplantBuilding</Template>
+        <Values>
+            <Standard>
+                <GUID>100780</GUID>
+                <Name>electricity_02 (Oil Power Plant)</Name>
+                <IconFilename>data/ui/2kimages/main/3dicons/icon_electric_works_oil.png</IconFilename>
+                <ID>OilPowerPlant</ID>
+                <InfoDescription>10946</InfoDescription>
+            </Standard>
+            <Maintenance>
+                <Maintenances>
+                    <Item>
+                        <Product>1010017</Product>
+                        <Amount>400</Amount>
+                        <InactiveAmount>200</InactiveAmount>
+                    </Item>
+                    <Item>
+                        <Product>1010117</Product>
+                        <Amount>150</Amount>
+                        <ShutdownThreshold>0.5</ShutdownThreshold>
+                    </Item>
+                </Maintenances>
+            </Maintenance>
+        </Values>
+    </Asset>
+</Assets>
+</Group>
+</Group>
+</AssetList>

--- a/tests/xml/merge/merge_strange_shit_unordered_patch.xml
+++ b/tests/xml/merge/merge_strange_shit_unordered_patch.xml
@@ -1,0 +1,18 @@
+<ModOps>
+<ModOp Type="merge" GUID='100780' Path="/Values/Maintenance">
+    <Maintenance>
+        <Maintenances>
+            <Item>
+                <InactiveAmount>30000</InactiveAmount>
+                <Product>1010017</Product>
+                <Amount>50000</Amount>
+            </Item>
+            <Item>
+                <Product>1010117</Product>
+                <Amount>150</Amount>
+                <ShutdownThreshold>1</ShutdownThreshold>
+            </Item>
+        </Maintenances>
+    </Maintenance>
+</ModOp>
+</ModOps>


### PR DESCRIPTION
This new implementation of the merge modop behaves the same as the old one (*according to the unit tests) - except that it ignores the node order among siblings.

Previous node traversal limitations (especially when not writing the full targeted node structure) should still apply (eg. deep accessing a node will not return to the previously used layer of nodes, but permanently move to the siblings of the deep-accessed node).

Code review appreciated as I'm not exactly used to C++.
Also, if you can think of more scenarios and edge cases to unit test (to make sure behaviour stays the same except for independence of node order among siblings), feel free to share ideas.

Fixes #171 .