### PR TITLE
Feature: Patch ModOp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,9 @@
 !.vscode/launch.json
 !.vscode/extensions.json
 
+#Visual Studio
+.vs/*
+
 # Private code that will not be shared publically
 /libs/internal/
 /.ccls-cache/

--- a/libs/xml-operations/include/xml_operations.h
+++ b/libs/xml-operations/include/xml_operations.h
@@ -12,7 +12,7 @@ namespace fs = std::filesystem;
 class XmlOperation
 {
   public:
-    enum Type { None, Add, AddNextSibling, AddPrevSibling, Remove, Replace, Merge };
+    enum class Type { None, Add, AddNextSibling, AddPrevSibling, Remove, Replace, Merge };
 
     XmlOperation(std::shared_ptr<pugi::xml_document> doc, pugi::xml_node node,
                  std::string guid = "", std::string temp = "", std::string mod_name = "",

--- a/libs/xml-operations/include/xml_operations.h
+++ b/libs/xml-operations/include/xml_operations.h
@@ -6,13 +6,15 @@
 #include <optional>
 #include <string>
 #include <vector>
+#include <stack>
+#include <unordered_set>
 
 namespace fs = std::filesystem;
 
 class XmlOperation
 {
   public:
-    enum class Type { None, Add, AddNextSibling, AddPrevSibling, Remove, Replace, Merge };
+    enum class Type { None, Add, AddNextSibling, AddPrevSibling, Remove, Replace, Merge, Patch };
 
     XmlOperation(std::shared_ptr<pugi::xml_document> doc, pugi::xml_node node,
                  std::string guid = "", std::string temp = "", std::string mod_name = "",
@@ -70,6 +72,10 @@ class XmlOperation
     }
     void RecursiveMerge(pugi::xml_node root_game_node, pugi::xml_node game_node,
                         pugi::xml_node patching_node);
+    void PatchOp(pugi::xml_object_range<pugi::xml_node_iterator> content_node,
+                 pugi::xml_node game_node);
+    void PatchNode(pugi::xml_node game_node, pugi::xml_node patching_node);
+
     void ReadPath(pugi::xml_node node, std::string guid = "", std::string temp = "");
     void ReadType(pugi::xml_node node, std::string mod_name, fs::path game_path, fs::path mod_path);
 

--- a/tests/xml/merge/merge_strange_shit_input.xml
+++ b/tests/xml/merge/merge_strange_shit_input.xml
@@ -30,5 +30,5 @@
     </Asset>
 </Assets>
 </Group>
-</Group>
+</Groups>
 </AssetList>

--- a/tests/xml/patch/patch_multi_node_content_1.json
+++ b/tests/xml/patch/patch_multi_node_content_1.json
@@ -1,0 +1,9 @@
+{
+    "name": "patch content",
+    "expected": [
+        "/Test/Node/FullSatisfactionDistance",
+        "/Test/Node/NoSatisfactionDistance",
+        "/Test/Node[FullSatisfactionDistance='60']",
+        "/Test/Node[NoSatisfactionDistance='90']"
+    ]
+}

--- a/tests/xml/patch/patch_multi_node_content_1_input.xml
+++ b/tests/xml/patch/patch_multi_node_content_1_input.xml
@@ -1,0 +1,6 @@
+<Test>
+    <Node>
+        <FullSatisfactionDistance>5</FullSatisfactionDistance>
+        <NoSatisfactionDistance>5</NoSatisfactionDistance>
+    </Node>
+</Test>

--- a/tests/xml/patch/patch_multi_node_content_1_patch.xml
+++ b/tests/xml/patch/patch_multi_node_content_1_patch.xml
@@ -1,0 +1,8 @@
+<ModOps>
+  <ModOp Type="patch" Path="/Test/Node">
+    <Node>
+      <FullSatisfactionDistance>60</FullSatisfactionDistance>
+      <NoSatisfactionDistance>90</NoSatisfactionDistance>
+    </Node>
+  </ModOp>
+</ModOps>

--- a/tests/xml/patch/patch_multi_node_content_2.json
+++ b/tests/xml/patch/patch_multi_node_content_2.json
@@ -1,0 +1,9 @@
+{
+    "name": "patch content nested",
+    "expected": [
+        "/Test/Node/FullSatisfactionDistance",
+        "/Test/Node/NoSatisfactionDistance",
+        "/Test/Node[FullSatisfactionDistance='60']",
+        "/Test/Node/NoSatisfactionDistance[NoSatisfactionDistance2='100']"
+    ]
+}

--- a/tests/xml/patch/patch_multi_node_content_2_input.xml
+++ b/tests/xml/patch/patch_multi_node_content_2_input.xml
@@ -1,0 +1,8 @@
+<Test>
+    <Node>
+        <FullSatisfactionDistance>5</FullSatisfactionDistance>
+        <NoSatisfactionDistance>
+            <NoSatisfactionDistance2>90</NoSatisfactionDistance2>
+        </NoSatisfactionDistance>
+    </Node>
+</Test>

--- a/tests/xml/patch/patch_multi_node_content_2_patch.xml
+++ b/tests/xml/patch/patch_multi_node_content_2_patch.xml
@@ -1,0 +1,10 @@
+<ModOps>
+  <ModOp Type="patch" Path="/Test/Node">
+    <Node>
+      <FullSatisfactionDistance>60</FullSatisfactionDistance>
+      <NoSatisfactionDistance>
+        <NoSatisfactionDistance2>100</NoSatisfactionDistance2>
+      </NoSatisfactionDistance>
+    </Node>
+  </ModOp>
+</ModOps>

--- a/tests/xml/patch/patch_multi_node_content_3.json
+++ b/tests/xml/patch/patch_multi_node_content_3.json
@@ -1,0 +1,9 @@
+{
+    "name": "patch content nested missing parent",
+    "expected": [
+        "/Test/Node/FullSatisfactionDistance",
+        "/Test/Node/NoSatisfactionDistance",
+        "/Test/Node[FullSatisfactionDistance='60']",
+        "/Test/Node/NoSatisfactionDistance[NoSatisfactionDistance2='90']"
+    ]
+}

--- a/tests/xml/patch/patch_multi_node_content_3_input.xml
+++ b/tests/xml/patch/patch_multi_node_content_3_input.xml
@@ -1,0 +1,8 @@
+<Test>
+    <Node>
+        <FullSatisfactionDistance>5</FullSatisfactionDistance>
+        <NoSatisfactionDistance>
+            <NoSatisfactionDistance2>90</NoSatisfactionDistance2>
+        </NoSatisfactionDistance>
+    </Node>
+</Test>

--- a/tests/xml/patch/patch_multi_node_content_3_patch.xml
+++ b/tests/xml/patch/patch_multi_node_content_3_patch.xml
@@ -1,0 +1,8 @@
+<ModOps>
+  <ModOp Type="patch" Path="/Test/Node">
+    <Node>
+      <FullSatisfactionDistance>60</FullSatisfactionDistance>
+      <NoSatisfactionDistance2>100</NoSatisfactionDistance2>
+    </Node>
+  </ModOp>
+</ModOps>

--- a/tests/xml/patch/patch_multi_node_content_fail.json
+++ b/tests/xml/patch/patch_multi_node_content_fail.json
@@ -1,0 +1,9 @@
+{
+    "name": "Multi node patch content - patching fails",
+    "expected": [
+        "/Test/Node/FullSatisfactionDistance",
+        "/Test/Node/NoSatisfactionDistance",
+        "/Test/Node[FullSatisfactionDistance='5']",
+        "/Test/Node[NoSatisfactionDistance='5']"
+    ]
+}

--- a/tests/xml/patch/patch_multi_node_content_fail_input.xml
+++ b/tests/xml/patch/patch_multi_node_content_fail_input.xml
@@ -1,0 +1,6 @@
+<Test>
+    <Node>
+        <FullSatisfactionDistance>5</FullSatisfactionDistance>
+        <NoSatisfactionDistance>5</NoSatisfactionDistance>
+    </Node>
+</Test>

--- a/tests/xml/patch/patch_multi_node_content_fail_patch.xml
+++ b/tests/xml/patch/patch_multi_node_content_fail_patch.xml
@@ -1,0 +1,6 @@
+<ModOps>
+  <ModOp Type="patch" Path="/Test/Node">
+    <FullSatisfactionDistance>60</FullSatisfactionDistance>
+    <NoSatisfactionDistance>90</NoSatisfactionDistance>
+  </ModOp>
+</ModOps>

--- a/tests/xml/patch/patch_second_child_only.json
+++ b/tests/xml/patch/patch_second_child_only.json
@@ -1,0 +1,7 @@
+{
+    "name": "patch second list child only without XPath",
+    "expected": [
+        "//Values/Cost/Costs/Item[Ingredient='1010017' and Amount='500']",
+        "//Values/Cost/Costs/Item[Ingredient='1010196' and Amount='123']"
+    ]
+}

--- a/tests/xml/patch/patch_second_child_only_input.xml
+++ b/tests/xml/patch/patch_second_child_only_input.xml
@@ -1,0 +1,151 @@
+<AssetList>
+<Groups>
+<Group>
+<Assets>
+<Asset>
+<Template>Warehouse</Template>
+<Values>
+    <Standard>
+        <GUID>1010371</GUID>
+        <Name>logistic_02 (Warehouse I)</Name>
+        <IconFilename>data/ui/2kimages/main/3dicons/icon_warehouse.png</IconFilename>
+        <InfoDescription>2975</InfoDescription>
+    </Standard>
+    <Text>
+        <LocaText>
+            <English>
+                <Text>Small Warehouse</Text>
+                <Status>Exported</Status>
+                <ExportCount>2</ExportCount>
+            </English>
+        </LocaText>
+        <LineID>6986</LineID>
+    </Text>
+    <Blocking>
+        <HasBuildingBaseTiles>1</HasBuildingBaseTiles>
+    </Blocking>
+    <Building>
+        <BuildingType>Logistic</BuildingType>
+        <BuildingCategoryName>11151</BuildingCategoryName>
+        <SkipUnlockMessage>1</SkipUnlockMessage>
+        <BuildModeRandomRotation>90</BuildModeRandomRotation>
+        <AssociatedRegions>Moderate</AssociatedRegions>
+    </Building>
+    <Cost>
+        <Costs>
+            <Item>
+                <Ingredient>1010017</Ingredient>
+                <Amount>500</Amount>
+            </Item>
+            <Item>
+                <Ingredient>1010196</Ingredient>
+                <Amount>10</Amount>
+            </Item>
+            <Item>
+                <Ingredient>1010205</Ingredient>
+            </Item>
+            <Item>
+                <Ingredient>1010218</Ingredient>
+            </Item>
+            <Item>
+                <Ingredient>1010207</Ingredient>
+            </Item>
+            <Item>
+                <Ingredient>1010202</Ingredient>
+            </Item>
+        </Costs>
+    </Cost>
+    <Selection>
+        <GUIType>Warehouse</GUIType>
+        <ParticipantMessageTrigger>ClickKontor</ParticipantMessageTrigger>
+        <Colors>
+            <WeakSelectionColorType>NoColor</WeakSelectionColorType>
+        </Colors>
+    </Selection>
+    <Object>
+        <Variations>
+            <Item>
+                <Filename>data/graphics/buildings/public/logistic_02/logistic_02.cfg</Filename>
+            </Item>
+        </Variations>
+    </Object>
+    <Constructable />
+    <Mesh />
+    <SoundEmitter>
+        <ActiveSounds>
+            <Item>
+                <Sound>200834</Sound>
+            </Item>
+        </ActiveSounds>
+        <DestroySounds>
+            <Item>
+                <Sound>9818756</Sound>
+            </Item>
+        </DestroySounds>
+        <BuildingRepaired>
+            <Item>
+                <Sound>203866</Sound>
+            </Item>
+        </BuildingRepaired>
+    </SoundEmitter>
+    <Locked />
+    <Infolayer />
+    <FeedbackController />
+    <Warehouse>
+        <WarehouseStorage>
+            <StorageMax>0</StorageMax>
+        </WarehouseStorage>
+    </Warehouse>
+    <LogisticNode />
+    <UpgradeList />
+    <AmbientMoodProvider>
+        <AmbientMood>ResidenceTier1</AmbientMood>
+    </AmbientMoodProvider>
+    <Maintenance>
+        <Maintenances>
+            <Item>
+                <Product>1010017</Product>
+                <Amount>20</Amount>
+                <InactiveAmount>20</InactiveAmount>
+            </Item>
+        </Maintenances>
+    </Maintenance>
+    <StorageBase />
+    <Attackable>
+        <MaximumHitPoints>2500</MaximumHitPoints>
+        <SelfHealPerHealTick>4</SelfHealPerHealTick>
+    </Attackable>
+    <Upgradable>
+        <NextGUID>100516</NextGUID>
+        <UpgradeCost>
+            <Item>
+                <Amount>2500</Amount>
+                <Ingredient>1010017</Ingredient>
+            </Item>
+            <Item>
+                <Amount>20</Amount>
+                <Ingredient>1010196</Ingredient>
+            </Item>
+            <Item>
+                <Amount>20</Amount>
+                <Ingredient>1010205</Ingredient>
+            </Item>
+            <Item>
+                <Ingredient>1010218</Ingredient>
+            </Item>
+            <Item>
+                <Ingredient>1010207</Ingredient>
+            </Item>
+            <Item>
+                <Ingredient>1010202</Ingredient>
+            </Item>
+        </UpgradeCost>
+        <CurrentTier>1</CurrentTier>
+    </Upgradable>
+    <Pausable />
+</Values>
+</Asset>
+</Assets>
+</Group>
+</Groups>
+</AssetList>

--- a/tests/xml/patch/patch_second_child_only_patch.xml
+++ b/tests/xml/patch/patch_second_child_only_patch.xml
@@ -1,0 +1,10 @@
+<ModOps>
+  <ModOp Type="patch" GUID="1010371" Path="/Values/Cost/Costs">
+    <Costs>
+      <Item />
+      <Item>
+        <Amount>123</Amount>
+      </Item>
+    </Costs>
+  </ModOp>
+</ModOps>

--- a/tests/xml/patch/patch_single_child_only.json
+++ b/tests/xml/patch/patch_single_child_only.json
@@ -1,0 +1,7 @@
+{
+    "name": "patch single child only",
+    "expected": [
+        "//Values/Cost/Costs/Item[Ingredient='1010017' and Amount='100']",
+        "//Values/Cost/Costs/Item[Ingredient='1010196' and Amount='10']"
+    ]
+}

--- a/tests/xml/patch/patch_single_child_only_input.xml
+++ b/tests/xml/patch/patch_single_child_only_input.xml
@@ -1,0 +1,151 @@
+<AssetList>
+<Groups>
+<Group>
+<Assets>
+<Asset>
+<Template>Warehouse</Template>
+<Values>
+    <Standard>
+        <GUID>1010371</GUID>
+        <Name>logistic_02 (Warehouse I)</Name>
+        <IconFilename>data/ui/2kimages/main/3dicons/icon_warehouse.png</IconFilename>
+        <InfoDescription>2975</InfoDescription>
+    </Standard>
+    <Text>
+        <LocaText>
+            <English>
+                <Text>Small Warehouse</Text>
+                <Status>Exported</Status>
+                <ExportCount>2</ExportCount>
+            </English>
+        </LocaText>
+        <LineID>6986</LineID>
+    </Text>
+    <Blocking>
+        <HasBuildingBaseTiles>1</HasBuildingBaseTiles>
+    </Blocking>
+    <Building>
+        <BuildingType>Logistic</BuildingType>
+        <BuildingCategoryName>11151</BuildingCategoryName>
+        <SkipUnlockMessage>1</SkipUnlockMessage>
+        <BuildModeRandomRotation>90</BuildModeRandomRotation>
+        <AssociatedRegions>Moderate</AssociatedRegions>
+    </Building>
+    <Cost>
+        <Costs>
+            <Item>
+                <Ingredient>1010017</Ingredient>
+                <Amount>500</Amount>
+            </Item>
+            <Item>
+                <Ingredient>1010196</Ingredient>
+                <Amount>10</Amount>
+            </Item>
+            <Item>
+                <Ingredient>1010205</Ingredient>
+            </Item>
+            <Item>
+                <Ingredient>1010218</Ingredient>
+            </Item>
+            <Item>
+                <Ingredient>1010207</Ingredient>
+            </Item>
+            <Item>
+                <Ingredient>1010202</Ingredient>
+            </Item>
+        </Costs>
+    </Cost>
+    <Selection>
+        <GUIType>Warehouse</GUIType>
+        <ParticipantMessageTrigger>ClickKontor</ParticipantMessageTrigger>
+        <Colors>
+            <WeakSelectionColorType>NoColor</WeakSelectionColorType>
+        </Colors>
+    </Selection>
+    <Object>
+        <Variations>
+            <Item>
+                <Filename>data/graphics/buildings/public/logistic_02/logistic_02.cfg</Filename>
+            </Item>
+        </Variations>
+    </Object>
+    <Constructable />
+    <Mesh />
+    <SoundEmitter>
+        <ActiveSounds>
+            <Item>
+                <Sound>200834</Sound>
+            </Item>
+        </ActiveSounds>
+        <DestroySounds>
+            <Item>
+                <Sound>9818756</Sound>
+            </Item>
+        </DestroySounds>
+        <BuildingRepaired>
+            <Item>
+                <Sound>203866</Sound>
+            </Item>
+        </BuildingRepaired>
+    </SoundEmitter>
+    <Locked />
+    <Infolayer />
+    <FeedbackController />
+    <Warehouse>
+        <WarehouseStorage>
+            <StorageMax>0</StorageMax>
+        </WarehouseStorage>
+    </Warehouse>
+    <LogisticNode />
+    <UpgradeList />
+    <AmbientMoodProvider>
+        <AmbientMood>ResidenceTier1</AmbientMood>
+    </AmbientMoodProvider>
+    <Maintenance>
+        <Maintenances>
+            <Item>
+                <Product>1010017</Product>
+                <Amount>20</Amount>
+                <InactiveAmount>20</InactiveAmount>
+            </Item>
+        </Maintenances>
+    </Maintenance>
+    <StorageBase />
+    <Attackable>
+        <MaximumHitPoints>2500</MaximumHitPoints>
+        <SelfHealPerHealTick>4</SelfHealPerHealTick>
+    </Attackable>
+    <Upgradable>
+        <NextGUID>100516</NextGUID>
+        <UpgradeCost>
+            <Item>
+                <Amount>2500</Amount>
+                <Ingredient>1010017</Ingredient>
+            </Item>
+            <Item>
+                <Amount>20</Amount>
+                <Ingredient>1010196</Ingredient>
+            </Item>
+            <Item>
+                <Amount>20</Amount>
+                <Ingredient>1010205</Ingredient>
+            </Item>
+            <Item>
+                <Ingredient>1010218</Ingredient>
+            </Item>
+            <Item>
+                <Ingredient>1010207</Ingredient>
+            </Item>
+            <Item>
+                <Ingredient>1010202</Ingredient>
+            </Item>
+        </UpgradeCost>
+        <CurrentTier>1</CurrentTier>
+    </Upgradable>
+    <Pausable />
+</Values>
+</Asset>
+</Assets>
+</Group>
+</Groups>
+</AssetList>

--- a/tests/xml/patch/patch_single_child_only_patch.xml
+++ b/tests/xml/patch/patch_single_child_only_patch.xml
@@ -1,0 +1,7 @@
+<ModOps>
+  <ModOp Type="patch" GUID="1010371" Path="/Values/Cost/Costs/Item[Ingredient='1010017']">
+    <Item>
+      <Amount>100</Amount>
+    </Item>
+  </ModOp>
+</ModOps>

--- a/tests/xml/patch/patch_strange_shit.json
+++ b/tests/xml/patch/patch_strange_shit.json
@@ -1,0 +1,7 @@
+{
+    "name": "patch strange shit",
+    "expected": [
+        "//Values/Maintenance/Maintenances/Item[Product='1010017' and Amount='50000' and InactiveAmount='30000']",
+        "//Values/Maintenance/Maintenances/Item[Product='101011799' and ShutdownThreshold='1']"
+    ]
+}

--- a/tests/xml/patch/patch_strange_shit_input.xml
+++ b/tests/xml/patch/patch_strange_shit_input.xml
@@ -1,0 +1,34 @@
+<AssetList>
+<Groups>
+<Group>
+<Assets>
+    <Asset>
+        <Template>PowerplantBuilding</Template>
+        <Values>
+            <Standard>
+                <GUID>100780</GUID>
+                <Name>electricity_02 (Oil Power Plant)</Name>
+                <IconFilename>data/ui/2kimages/main/3dicons/icon_electric_works_oil.png</IconFilename>
+                <ID>OilPowerPlant</ID>
+                <InfoDescription>10946</InfoDescription>
+            </Standard>
+            <Maintenance>
+                <Maintenances>
+                    <Item>
+                        <Product>1010017</Product>
+                        <Amount>400</Amount>
+                        <InactiveAmount>200</InactiveAmount>
+                    </Item>
+                    <Item>
+                        <Product>1010117</Product>
+                        <Amount>150</Amount>
+                        <ShutdownThreshold>0.5</ShutdownThreshold>
+                    </Item>
+                </Maintenances>
+            </Maintenance>
+        </Values>
+    </Asset>
+</Assets>
+</Group>
+</Group>
+</AssetList>

--- a/tests/xml/patch/patch_strange_shit_patch.xml
+++ b/tests/xml/patch/patch_strange_shit_patch.xml
@@ -1,0 +1,17 @@
+<ModOps>
+<ModOp Type="patch" GUID='100780' Path="/Values/Maintenance">
+    <Maintenance>
+        <Maintenances>
+            <Item>
+                <Product>1010017</Product>
+                <Amount>50000</Amount>
+                <InactiveAmount>30000</InactiveAmount>
+            </Item>
+            <Item>
+                <Product>101011799</Product>
+                <ShutdownThreshold>1</ShutdownThreshold>
+            </Item>
+        </Maintenances>
+    </Maintenance>
+</ModOp>
+</ModOps>

--- a/tests/xml/patch/patch_strange_shit_unordered.json
+++ b/tests/xml/patch/patch_strange_shit_unordered.json
@@ -1,0 +1,7 @@
+{
+    "name": "patch strange shit unordered",
+    "expected": [
+        "//Values/Maintenance/Maintenances/Item[Product='1010017' and Amount='50000' and InactiveAmount='30000']",
+        "//Values/Maintenance/Maintenances/Item[Product='101011799' and ShutdownThreshold='1']"
+    ]
+}

--- a/tests/xml/patch/patch_strange_shit_unordered_input.xml
+++ b/tests/xml/patch/patch_strange_shit_unordered_input.xml
@@ -1,0 +1,34 @@
+<AssetList>
+<Groups>
+<Group>
+<Assets>
+    <Asset>
+        <Template>PowerplantBuilding</Template>
+        <Values>
+            <Standard>
+                <GUID>100780</GUID>
+                <Name>electricity_02 (Oil Power Plant)</Name>
+                <IconFilename>data/ui/2kimages/main/3dicons/icon_electric_works_oil.png</IconFilename>
+                <ID>OilPowerPlant</ID>
+                <InfoDescription>10946</InfoDescription>
+            </Standard>
+            <Maintenance>
+                <Maintenances>
+                    <Item>
+                        <Product>1010017</Product>
+                        <Amount>400</Amount>
+                        <InactiveAmount>200</InactiveAmount>
+                    </Item>
+                    <Item>
+                        <Product>1010117</Product>
+                        <Amount>150</Amount>
+                        <ShutdownThreshold>0.5</ShutdownThreshold>
+                    </Item>
+                </Maintenances>
+            </Maintenance>
+        </Values>
+    </Asset>
+</Assets>
+</Group>
+</Group>
+</AssetList>

--- a/tests/xml/patch/patch_strange_shit_unordered_patch.xml
+++ b/tests/xml/patch/patch_strange_shit_unordered_patch.xml
@@ -1,0 +1,17 @@
+<ModOps>
+<ModOp Type="patch" GUID='100780' Path="/Values/Maintenance">
+    <Maintenance>
+        <Maintenances>
+            <Item>
+                <InactiveAmount>30000</InactiveAmount>
+                <Product>1010017</Product>
+                <Amount>50000</Amount>
+            </Item>
+            <Item>
+                <ShutdownThreshold>1</ShutdownThreshold>
+                <Product>101011799</Product>
+            </Item>
+        </Maintenances>
+    </Maintenance>
+</ModOp>
+</ModOps>

--- a/tests/xml/patch/simple_patch_attribute.json
+++ b/tests/xml/patch/simple_patch_attribute.json
@@ -1,0 +1,7 @@
+{
+    "name": "Simple patch Attribute",
+    "expected": [
+        "/Test/Node/Meow",
+        "/Test/Node[@Attr='Meow']"
+    ]
+}

--- a/tests/xml/patch/simple_patch_attribute_input.xml
+++ b/tests/xml/patch/simple_patch_attribute_input.xml
@@ -1,0 +1,5 @@
+<Test>
+    <Node>
+        <Meow />
+    </Node>
+</Test>

--- a/tests/xml/patch/simple_patch_attribute_patch.xml
+++ b/tests/xml/patch/simple_patch_attribute_patch.xml
@@ -1,0 +1,5 @@
+<ModOps>
+  <ModOp Type="patch" Path="/Test/Node">
+    <Node Attr="Meow"></Node>
+  </ModOp>
+</ModOps>

--- a/tests/xml/patch/simple_patch_content.json
+++ b/tests/xml/patch/simple_patch_content.json
@@ -1,0 +1,7 @@
+{
+    "name": "Simple patch content",
+    "expected": [
+        "/Test/Node/Meow",
+        "/Test/Node[Meow='10']"
+    ]
+}

--- a/tests/xml/patch/simple_patch_content_input.xml
+++ b/tests/xml/patch/simple_patch_content_input.xml
@@ -1,0 +1,5 @@
+<Test>
+    <Node>
+        <Meow>5</Meow>
+    </Node>
+</Test>

--- a/tests/xml/patch/simple_patch_content_patch.xml
+++ b/tests/xml/patch/simple_patch_content_patch.xml
@@ -1,0 +1,5 @@
+<ModOps>
+  <ModOp Type="patch" Path="/Test/Node/Meow">
+    <Meow>10</Meow>
+  </ModOp>
+</ModOps>


### PR DESCRIPTION
A Patch modop that is functionally identical to the explicitMerge from #174 but does nor run recursively, instead using its own stack.

This iterates over the tree structure of a game and a patch node. Only a single patch node may be used, and all patch entries must exactly match the target structure.

This ModOp does not run recursively, but is not neccessarily more space efficient since all patch children still get put on a (local) stack. This was easiest to implement, since it's easy to use the next patch sibling on a successful patch, but not on a failed patch, since it would silently fail by empty stack, not patching any following patches.

Has the Unit tests from the (recursive) explicitMerge PR, just renamed to the patch ModOp.

There's some other small changes in this PR, since the gitignore did not previously ignore the visual studio state folder (.vs), only the VSCode state. Also made an enum into an enum class for the better type safety and fixed a wrong XML closing tag in a test file.