### PR TITLE
Add `AllowNoMatch` attribute to hide no match warning

### DIFF
--- a/libs/xml-operations/include/xml_operations.h
+++ b/libs/xml-operations/include/xml_operations.h
@@ -49,6 +49,7 @@ class XmlOperation
     pugi::xml_node node_;
 
     bool           skip_ = false;
+    bool           allow_no_match_ = false;
 
     std::string mod_name_;
     fs::path    game_path_;

--- a/libs/xml-operations/src/xml_operations.cc
+++ b/libs/xml-operations/src/xml_operations.cc
@@ -63,6 +63,7 @@ XmlOperation::XmlOperation(std::shared_ptr<pugi::xml_document> doc, pugi::xml_no
     }
 
     skip_ = node.attribute("Skip");
+    allow_no_match_ = node.attribute("AllowNoMatch");
 }
 
 void XmlOperation::ReadPath(pugi::xml_node node, std::string guid, std::string temp)
@@ -359,8 +360,15 @@ void XmlOperation::Apply(std::shared_ptr<pugi::xml_document> doc)
             offset_data_t offset_data;
             build_offset_data(offset_data, mod_path_.string().c_str());
             auto [line, column] = get_location(offset_data, node_.offset_debug());
-            spdlog::warn("No matching node for Path {} in {} ({}:{})", GetPath(), mod_name_,
-                         game_path_.string(), line);
+
+            const std::string msg = "No matching node for Path {} in {} ({}:{})";
+            if (allow_no_match_) {
+                spdlog::debug(msg, GetPath(), mod_name_, game_path_.string(), line);
+            }
+            else {
+                spdlog::warn(msg, GetPath(), mod_name_, game_path_.string(), line);
+            }
+
             return;
         }
 

--- a/tests/xml/gen_tests.py
+++ b/tests/xml/gen_tests.py
@@ -39,6 +39,14 @@ def main():
                         else:
                             f.write("CHECK(runner.PathExists(\"" +
                                     expected_path + "\"));")
+
+                    # check log warnings
+                    f.write("INFO(runner.DumpLog());")
+                    if data.get("issuesExpected", "0") == "1":
+                        f.write("CHECK(runner.HasIssues());")
+                    else:
+                        f.write("CHECK_FALSE(runner.HasIssues());")
+
                     f.write("}\n\n")
 
 

--- a/tests/xml/noMatchWarning/no_match_allow.json
+++ b/tests/xml/noMatchWarning/no_match_allow.json
@@ -1,0 +1,7 @@
+{
+    "name": "Add No Allow",
+    "expected": [
+        "/Test/Node/Meow[GUID='1']"
+    ],
+    "issuesExpected": "0"
+}

--- a/tests/xml/noMatchWarning/no_match_allow_input.xml
+++ b/tests/xml/noMatchWarning/no_match_allow_input.xml
@@ -1,0 +1,5 @@
+<Test>
+    <Node>
+        <Meow><GUID>1</GUID></Meow>
+    </Node>
+</Test>

--- a/tests/xml/noMatchWarning/no_match_allow_patch.xml
+++ b/tests/xml/noMatchWarning/no_match_allow_patch.xml
@@ -1,0 +1,5 @@
+<ModOps>
+<ModOp Type="addNextSibling" Path="/Test/Node/Meow[GUID='2']" AllowNoMatch="1">
+    <Meow><GUID>3</GUID></Meow>
+</ModOp>
+</ModOps>

--- a/tests/xml/noMatchWarning/no_match_warning.json
+++ b/tests/xml/noMatchWarning/no_match_warning.json
@@ -1,0 +1,7 @@
+{
+    "name": "Add No Match",
+    "expected": [
+        "/Test/Node/Meow[GUID='1']"
+    ],
+    "issuesExpected": "1"
+}

--- a/tests/xml/noMatchWarning/no_match_warning_input.xml
+++ b/tests/xml/noMatchWarning/no_match_warning_input.xml
@@ -1,0 +1,5 @@
+<Test>
+    <Node>
+        <Meow><GUID>1</GUID></Meow>
+    </Node>
+</Test>

--- a/tests/xml/noMatchWarning/no_match_warning_patch.xml
+++ b/tests/xml/noMatchWarning/no_match_warning_patch.xml
@@ -1,0 +1,5 @@
+<ModOps>
+<ModOp Type="addNextSibling" Path="/Test/Node/Meow[GUID='2']">
+    <Meow><GUID>3</GUID></Meow>
+</ModOp>
+</ModOps>

--- a/tests/xml/runner.h
+++ b/tests/xml/runner.h
@@ -1,4 +1,6 @@
 #include "pugixml.hpp"
+#include "spdlog/sinks/ostream_sink.h"
+#include "spdlog/spdlog.h"
 
 #include "xml_operations.h"
 
@@ -14,6 +16,13 @@ class TestRunner
 {
 public:
     TestRunner(std::string_view mod_path, std::string_view input, std::string_view patch) {
+        {
+            auto sink = std::make_shared<spdlog::sinks::ostream_sink_st>(test_log_);
+            auto test_logger = std::make_shared<spdlog::logger>("test_logger", sink);
+            test_logger->set_pattern("[%l] %v");
+            test_logger->set_level(spdlog::level::info);
+            spdlog::set_default_logger(test_logger);
+        }
         {
             xml_operations_ = XmlOperation::GetXmlOperationsFromFile(patch, "", input, mod_path);
         }
@@ -42,7 +51,6 @@ public:
         return exists;
     }
 
-
     std::string DumpXml() {
         std::stringstream ss;
         input_doc_->print(ss, "   ");
@@ -50,8 +58,26 @@ public:
         return buf;
     }
 
-    ~TestRunner() = default;
+    bool HasIssues() {
+        auto log_content = test_log_.str();
+        
+        if (log_content.find("[warning]") != std::string::npos || 
+            log_content.find("[error]") != std::string::npos) {
+            return true;
+        }
+
+        return false;
+    }
+
+    std::string DumpLog() {
+        return test_log_.str();
+    }
+
+    ~TestRunner() {
+        spdlog::drop("test_logger");
+    }
 private:
     std::vector<XmlOperation> xml_operations_;
     std::shared_ptr<pugi::xml_document> input_doc_ = nullptr;
+    std::ostringstream test_log_;
 };


### PR DESCRIPTION
Background:
ModOps with no matches are inevitable when ensuring compatibility across several mods.
The current work around to avoid warnings is to add lots of fake data first - which is error prone and clutters mods needlessly.

Closes #176

Change:
1. Add check for `[warning]` and `[error]` to all test cases (via runner, test cases are untouched).
2. Add `AllowNoMatch` as an optional attribute to ModOps to switch the "no matching node found" message from warning to debug level.
3. Add unit tests to confirm the warning is produced without `AllowNoMatch`, and no warning is produced with the attribute.

