### PR TITLE
add test for commonly used XPath fallback

### DIFF
--- a/tests/xml/xpath_or/xpath_or.json
+++ b/tests/xml/xpath_or/xpath_or.json
@@ -1,0 +1,7 @@
+{
+    "name": "XPath | Behavior",
+    "expected": [
+        "!/Test/Asset/Values[Standard/GUID='5']/Meow",
+        "/Test/Asset/Values[Standard/GUID='4']/Meow"
+    ]
+}

--- a/tests/xml/xpath_or/xpath_or_input.xml
+++ b/tests/xml/xpath_or/xpath_or_input.xml
@@ -1,0 +1,18 @@
+<Test>
+    <Asset>
+        <Values>
+            <Standard>
+                <GUID>5</GUID>
+            </Standard>
+            <Meow>5</Meow>
+        </Values>
+    </Asset>
+    <Asset>
+        <Values>
+            <Standard>
+                <GUID>4</GUID>
+            </Standard>
+            <Meow>4</Meow>
+        </Values>
+    </Asset>
+</Test>

--- a/tests/xml/xpath_or/xpath_or_patch.xml
+++ b/tests/xml/xpath_or/xpath_or_patch.xml
@@ -1,0 +1,3 @@
+<ModOps>
+<ModOp Type="remove" GUID="7" Path="/Values/Meow | //Asset/Values[Standard/GUID='5']/Meow" />
+</ModOps>


### PR DESCRIPTION
One example usage is adding products to product lists, but only if they are not there yet.

The approach is to add a temporary container and fallback to that one to avoid warnings.

Some examples for Hotel mod compatibility:
https://github.com/anno-mods/shared-resources/blob/main/compat/assets-hotel-needs.include.xml

~~Marked as draft because Windows CI doesn't work currently.
edit: it kicks of even on draft...~~