### PR TITLE
add `Condition` attribute to ModOps

### DIFF
--- a/cmd/xmltest/src/main.cc
+++ b/cmd/xmltest/src/main.cc
@@ -30,7 +30,7 @@ int main(int argc, const char **argv)
         doc->load_buffer(buffer.data(), buffer.size());
     }
 
-    auto operations = XmlOperation::GetXmlOperationsFromFile(argv[2]);
+    auto operations = XmlOperation::GetXmlOperationsFromFile(argv[2], "", {}, fs::absolute(fs::current_path()));
     for (auto &&operation : operations) {
         operation.Apply(doc);
     }

--- a/libs/external-file-loader/src/mod_manager.cc
+++ b/libs/external-file-loader/src/mod_manager.cc
@@ -217,10 +217,9 @@ void ModManager::WaitModsReady() const
 
 Mod& ModManager::GetModContainingFile(const fs::path& file)
 {
+    const auto file_path_str = file.lexically_normal().generic_string();
     for (auto& mod : mods_) {
-        if (file.lexically_normal().generic_string().find(
-                mod.Path().lexically_normal().generic_string())
-            == 0) {
+        if (file_path_str.find((mod.Path() / "").lexically_normal().generic_string()) == 0) {
             return mod;
         }
     }
@@ -489,7 +488,7 @@ void ModManager::GameFilesReady()
                     // Cache miss
                     auto& mod        = GetModContainingFile(on_disk_file);
                     auto  operations = XmlOperation::GetXmlOperationsFromFile(
-                         on_disk_file, mod.Name(), game_path, on_disk_file);
+                         on_disk_file, mod.Name(), game_path, mod.Path());
                     for (auto&& operation : operations) {
                         operation.Apply(game_xml);
                     }

--- a/libs/xml-operations/include/xml_operations.h
+++ b/libs/xml-operations/include/xml_operations.h
@@ -49,6 +49,7 @@ class XmlOperation
     pugi::xml_node node_;
 
     bool           skip_ = false;
+    bool           allow_no_match_ = false;
 
     std::string mod_name_;
     fs::path    game_path_;

--- a/libs/xml-operations/include/xml_operations.h
+++ b/libs/xml-operations/include/xml_operations.h
@@ -16,7 +16,7 @@ class XmlOperation
 
     XmlOperation(std::shared_ptr<pugi::xml_document> doc, pugi::xml_node node,
                  std::string guid = "", std::string temp = "", std::string mod_name = "",
-                 fs::path game_path = {}, fs::path mod_path = {});
+                 fs::path game_path = {}, fs::path mod_path = {}, fs::path mod_base_path = {});
 
     pugi::xml_object_range<pugi::xml_node_iterator> GetContentNode();
     Type                                            GetType() const;
@@ -26,14 +26,14 @@ class XmlOperation
 
   public:
     static std::vector<XmlOperation> GetXmlOperations(std::shared_ptr<pugi::xml_document> doc,
-                                                      std::string mod_name  = "",
-                                                      fs::path    game_path = {},
-                                                      fs::path    mod_path  = {},
-                                                      fs::path    doc_path  = {});
-    static std::vector<XmlOperation> GetXmlOperationsFromFile(fs::path    path,
-                                                              std::string mod_name  = "",
-                                                              fs::path    game_path = {},
-                                                              fs::path    mod_path  = {});
+                                                      std::string mod_name       = "",
+                                                      fs::path    game_path      = {},
+                                                      fs::path    mod_path       = {},
+                                                      fs::path    mod_base_path  = {});
+    static std::vector<XmlOperation> GetXmlOperationsFromFile(fs::path    mod_path,
+                                                              std::string mod_name       = "",
+                                                              fs::path    game_path      = {},
+                                                              fs::path    mod_base_path  = {});
 
   private:
     Type        type_;
@@ -53,6 +53,7 @@ class XmlOperation
     std::string mod_name_;
     fs::path    game_path_;
     fs::path    mod_path_;
+    fs::path    mod_base_path_;
 
     enum SpeculativePathType {
         NONE,
@@ -71,7 +72,8 @@ class XmlOperation
     void RecursiveMerge(pugi::xml_node root_game_node, pugi::xml_node game_node,
                         pugi::xml_node patching_node);
     void ReadPath(pugi::xml_node node, std::string guid = "", std::string temp = "");
-    void ReadType(pugi::xml_node node, std::string mod_name, fs::path game_path, fs::path mod_path);
+    void ReadType(pugi::xml_node node, std::string mod_name, fs::path game_path, fs::path mod_path,
+                  fs::path mod_base_path);
 
     std::optional<pugi::xml_node> FindAsset(std::string guid, pugi::xml_node node);
     std::optional<pugi::xml_node> FindTemplate(std::string temp, pugi::xml_node node);

--- a/libs/xml-operations/include/xml_operations.h
+++ b/libs/xml-operations/include/xml_operations.h
@@ -49,6 +49,7 @@ class XmlOperation
     pugi::xml_node node_;
 
     bool           skip_ = false;
+    std::string    condition_;
 
     std::string mod_name_;
     fs::path    game_path_;
@@ -83,4 +84,6 @@ class XmlOperation
 
     pugi::xpath_node_set ReadGuidNodes(std::shared_ptr<pugi::xml_document> doc);
     pugi::xpath_node_set ReadTemplateNodes(std::shared_ptr<pugi::xml_document> doc);
+
+    bool CheckCondition(std::shared_ptr<pugi::xml_document> doc);
 };

--- a/libs/xml-operations/src/xml_operations.cc
+++ b/libs/xml-operations/src/xml_operations.cc
@@ -440,7 +440,13 @@ std::vector<XmlOperation> XmlOperation::GetXmlOperations(std::shared_ptr<pugi::x
                     }
                 } else if (stricmp(node.name(), "Include") == 0) {
                     const auto file = GetXmlPropString(node, "File");
-                    const auto file_path = mod_path.parent_path() / file;
+                    fs::path file_path;
+                    if (file.rfind("/", 0) == 0) {
+                        file_path = mod_base_path;
+                        file_path += file;
+                    } else {
+                        file_path = mod_path.parent_path() / file;
+                    }
 
                     auto include_ops = GetXmlOperationsFromFile(file_path.lexically_normal(), 
                                                                 mod_name, game_path, mod_base_path);

--- a/libs/xml-operations/src/xml_operations.cc
+++ b/libs/xml-operations/src/xml_operations.cc
@@ -63,6 +63,7 @@ XmlOperation::XmlOperation(std::shared_ptr<pugi::xml_document> doc, pugi::xml_no
     }
 
     skip_ = node.attribute("Skip");
+    allow_no_match_ = node.attribute("AllowNoMatch");
 }
 
 void XmlOperation::ReadPath(pugi::xml_node node, std::string guid, std::string temp)
@@ -359,8 +360,15 @@ void XmlOperation::Apply(std::shared_ptr<pugi::xml_document> doc)
             offset_data_t offset_data;
             build_offset_data(offset_data, mod_path_.string().c_str());
             auto [line, column] = get_location(offset_data, node_.offset_debug());
-            spdlog::warn("No matching node for Path {} in {} ({}:{})", GetPath(), mod_name_,
-                         game_path_.string(), line);
+
+            const std::string msg = "No matching node for Path {} in {} ({}:{})";
+            if (allow_no_match_) {
+                spdlog::debug(msg, GetPath(), mod_name_, game_path_.string(), line);
+            }
+            else {
+                spdlog::warn(msg, GetPath(), mod_name_, game_path_.string(), line);
+            }
+
             return;
         }
 

--- a/libs/xml-operations/src/xml_operations.cc
+++ b/libs/xml-operations/src/xml_operations.cc
@@ -435,11 +435,14 @@ std::vector<XmlOperation> XmlOperation::GetXmlOperations(std::shared_ptr<pugi::x
                         mod_operations.emplace_back(doc, node, "", "", mod_name, game_path, mod_path);
                     }
                 } else if (stricmp(node.name(), "Include") == 0) {
-                    const auto file = GetXmlPropString(node, "File");
-                    auto       include_ops =
-                        GetXmlOperationsFromFile(doc_path / file, mod_name, game_path, mod_path);
-                    mod_operations.insert(std::end(mod_operations), std::begin(include_ops),
-                                          std::end(include_ops));
+                    const bool skip = node.attribute("Skip");
+                    if (!skip) {
+                        const auto file = GetXmlPropString(node, "File");
+                        auto       include_ops =
+                            GetXmlOperationsFromFile(doc_path / file, mod_name, game_path, mod_path);
+                        mod_operations.insert(std::end(mod_operations), std::begin(include_ops),
+                                            std::end(include_ops));
+                    }
                 }
             }
         }

--- a/libs/xml-operations/src/xml_operations.cc
+++ b/libs/xml-operations/src/xml_operations.cc
@@ -45,19 +45,20 @@ static std::pair<size_t, size_t> get_location(const offset_data_t &data, ptrdiff
 
 XmlOperation::XmlOperation(std::shared_ptr<pugi::xml_document> doc, pugi::xml_node node,
                            std::string guid, std::string temp, std::string mod_name,
-                           fs::path game_path, fs::path mod_path)
+                           fs::path game_path, fs::path mod_path, fs::path mod_base_path)
 {
     guid_     = guid;
     template_ = temp;
     node_     = node;
     doc_      = doc;
 
-    mod_name_  = mod_name;
-    game_path_ = game_path;
-    mod_path_  = mod_path;
+    mod_name_      = mod_name;
+    game_path_     = game_path;
+    mod_path_      = mod_path;
+    mod_base_path_ = mod_base_path;
 
     ReadPath(node, guid, temp);
-    ReadType(node, mod_name, game_path, mod_path);
+    ReadType(node, mod_name, game_path, mod_path, mod_base_path);
     if (type_ != Type::Remove) {
         nodes_ = node.children();
     }
@@ -155,7 +156,7 @@ void XmlOperation::ReadPath(pugi::xml_node node, std::string guid, std::string t
 }
 
 void XmlOperation::ReadType(pugi::xml_node node, std::string mod_name, fs::path game_path,
-                            fs::path mod_path)
+                            fs::path mod_path, fs::path mod_base_path)
 {
 #ifndef _WIN32
     auto stricmp = [](auto a, auto b) { return strcasecmp(a, b); };
@@ -181,7 +182,7 @@ void XmlOperation::ReadType(pugi::xml_node node, std::string mod_name, fs::path 
         build_offset_data(offset_data, mod_path.string().c_str());
         auto [line, column] = get_location(offset_data, node_.offset_debug());
         spdlog::warn("No matching node for Path {} in {} ({}:{})", GetPath(), mod_name,
-                     game_path.string(), line);
+                     mod_path_.lexically_relative(mod_base_path_).string(), line);
         spdlog::error("Unknown ModOp({}), ignoring {}", type, GetPath());
     }
 }
@@ -360,7 +361,7 @@ void XmlOperation::Apply(std::shared_ptr<pugi::xml_document> doc)
             build_offset_data(offset_data, mod_path_.string().c_str());
             auto [line, column] = get_location(offset_data, node_.offset_debug());
             spdlog::warn("No matching node for Path {} in {} ({}:{})", GetPath(), mod_name_,
-                         game_path_.string(), line);
+                         mod_path_.lexically_relative(mod_base_path_).string(), line);
             return;
         }
 
@@ -403,7 +404,7 @@ void XmlOperation::Apply(std::shared_ptr<pugi::xml_document> doc)
 
 std::vector<XmlOperation> XmlOperation::GetXmlOperations(std::shared_ptr<pugi::xml_document> doc,
                                                          std::string mod_name, fs::path game_path,
-                                                         fs::path mod_path, fs::path doc_path)
+                                                         fs::path mod_path, fs::path mod_base_path)
 {
 #ifndef _WIN32
     auto stricmp = [](auto a, auto b) { return strcasecmp(a, b); };
@@ -427,17 +428,22 @@ std::vector<XmlOperation> XmlOperation::GetXmlOperations(std::shared_ptr<pugi::x
                     if (!guid.empty()) {
                         std::vector<std::string> guids = absl::StrSplit(guid, ',');
                         for (auto g : guids) {
-                            mod_operations.emplace_back(doc, node, g.data(), "", mod_name, game_path, mod_path);
+                            mod_operations.emplace_back(doc, node, g.data(), "", mod_name, game_path, 
+                                                        mod_path, mod_base_path);
                         }   
                     } else if (!temp.empty()) {
-                        mod_operations.emplace_back(doc, node, "", temp, mod_name, game_path, mod_path);
+                        mod_operations.emplace_back(doc, node, "", temp, mod_name, game_path, mod_path, 
+                                                    mod_base_path);
                     } else {
-                        mod_operations.emplace_back(doc, node, "", "", mod_name, game_path, mod_path);
+                        mod_operations.emplace_back(doc, node, "", "", mod_name, game_path, mod_path, 
+                                                    mod_base_path);
                     }
                 } else if (stricmp(node.name(), "Include") == 0) {
                     const auto file = GetXmlPropString(node, "File");
-                    auto       include_ops =
-                        GetXmlOperationsFromFile(doc_path / file, mod_name, game_path, mod_path);
+                    const auto file_path = mod_path.parent_path() / file;
+
+                    auto include_ops = GetXmlOperationsFromFile(file_path.lexically_normal(), 
+                                                                mod_name, game_path, mod_base_path);
                     mod_operations.insert(std::end(mod_operations), std::begin(include_ops),
                                           std::end(include_ops));
                 }
@@ -449,23 +455,23 @@ std::vector<XmlOperation> XmlOperation::GetXmlOperations(std::shared_ptr<pugi::x
     return mod_operations;
 }
 
-std::vector<XmlOperation> XmlOperation::GetXmlOperationsFromFile(fs::path    path,
+std::vector<XmlOperation> XmlOperation::GetXmlOperationsFromFile(fs::path    mod_path,
                                                                  std::string mod_name,
                                                                  fs::path    game_path,
-                                                                 fs::path    mod_path)
+                                                                 fs::path    mod_base_path)
 {
     std::shared_ptr<pugi::xml_document> doc          = std::make_shared<pugi::xml_document>();
-    auto                                parse_result = doc->load_file(path.string().c_str());
+    auto                                parse_result = doc->load_file(mod_path.string().c_str());
     if (!parse_result) {
         offset_data_t offset_data;
-        build_offset_data(offset_data, path.string().c_str());
+        build_offset_data(offset_data, mod_path.string().c_str());
         auto location = get_location(offset_data, parse_result.offset);
-        spdlog::error("[{}] Failed to parse {}({}, {}): {}", mod_name, path.string(),
+        spdlog::error("[{}] Failed to parse {}({}, {}): {}", mod_name, mod_path.string(),
                       location.first, location.second, parse_result.description());
         return {};
     }
-    const auto doc_path = path.lexically_normal().parent_path();
-    return GetXmlOperations(doc, mod_name, game_path, mod_path, doc_path);
+
+    return GetXmlOperations(doc, mod_name, game_path, mod_path, mod_base_path);
 }
 
 void MergeProperties(pugi::xml_node game_node, pugi::xml_node patching_node)

--- a/tests/xml/condition/condition_match.json
+++ b/tests/xml/condition/condition_match.json
@@ -1,0 +1,8 @@
+{
+    "name": "Condition Match",
+    "expected": [
+        "/Test/Node[Meow='5']",
+        "/Test/Node[Meow='3']",
+        "!/Test/Node[Meow='2']"
+    ]
+}

--- a/tests/xml/condition/condition_match_input.xml
+++ b/tests/xml/condition/condition_match_input.xml
@@ -1,0 +1,6 @@
+<Test>
+    <Node>
+        <Meow>5</Meow>
+        <Meow>4</Meow>
+    </Node>
+</Test>

--- a/tests/xml/condition/condition_match_patch.xml
+++ b/tests/xml/condition/condition_match_patch.xml
@@ -1,0 +1,8 @@
+<ModOps>
+<ModOp Type="add" Path="/Test/Node[Meow='5']" Condition="/Test/Node[Meow='4']">
+    <Meow>3</Meow>
+</ModOp>
+<ModOp Type="add" Path="/Test/Node[Meow='5']" Condition="/Test/Node[Meow='1']">
+    <Meow>2</Meow>
+</ModOp>
+</ModOps>

--- a/tests/xml/condition/condition_no_match.json
+++ b/tests/xml/condition/condition_no_match.json
@@ -1,0 +1,8 @@
+{
+    "name": "Condition No Match",
+    "expected": [
+        "/Test/Node[Meow='5']",
+        "/Test/Node[Meow='3']",
+        "!/Test/Node[Meow='2']"
+    ]
+}

--- a/tests/xml/condition/condition_no_match_input.xml
+++ b/tests/xml/condition/condition_no_match_input.xml
@@ -1,0 +1,6 @@
+<Test>
+    <Node>
+        <Meow>5</Meow>
+        <Meow>4</Meow>
+    </Node>
+</Test>

--- a/tests/xml/condition/condition_no_match_patch.xml
+++ b/tests/xml/condition/condition_no_match_patch.xml
@@ -1,0 +1,8 @@
+<ModOps>
+<ModOp Type="add" Path="/Test/Node[Meow='5']" Condition="!/Test/Node[Meow='1']">
+    <Meow>3</Meow>
+</ModOp>
+<ModOp Type="add" Path="/Test/Node[Meow='5']" Condition="!/Test/Node[Meow='4']">
+    <Meow>2</Meow>
+</ModOp>
+</ModOps>

--- a/tests/xml/gen_tests.py
+++ b/tests/xml/gen_tests.py
@@ -39,6 +39,14 @@ def main():
                         else:
                             f.write("CHECK(runner.PathExists(\"" +
                                     expected_path + "\"));")
+
+                    # check log warnings
+                    f.write("INFO(runner.DumpLog());")
+                    if data.get("issuesExpected", "0") == "1":
+                        f.write("CHECK(runner.HasIssues());")
+                    else:
+                        f.write("CHECK_FALSE(runner.HasIssues());")
+
                     f.write("}\n\n")
 
 

--- a/tests/xml/include/config/export/include_absolute_path_input.xml
+++ b/tests/xml/include/config/export/include_absolute_path_input.xml
@@ -1,0 +1,5 @@
+<Test>
+    <Node>
+        <Meow />
+    </Node>
+</Test>

--- a/tests/xml/include/config/export/include_absolute_path_patch.xml
+++ b/tests/xml/include/config/export/include_absolute_path_patch.xml
@@ -1,0 +1,3 @@
+<ModOps>
+    <Include File="/config/export/include_nontrivial_input.xml" />
+</ModOps>

--- a/tests/xml/include/include_absolute_path.json
+++ b/tests/xml/include/include_absolute_path.json
@@ -1,0 +1,9 @@
+{
+    "name": "Include from absolute path",
+    "folder": "config/export",
+    "expected": [
+        "/Test/Node/Meow",
+        "/Test/Node[Cat='10']",
+        "/Test/Node[Cat2='10']"
+    ]
+}

--- a/tests/xml/noMatchWarning/no_match_allow.json
+++ b/tests/xml/noMatchWarning/no_match_allow.json
@@ -1,0 +1,7 @@
+{
+    "name": "Add No Allow",
+    "expected": [
+        "/Test/Node/Meow[GUID='1']"
+    ],
+    "issuesExpected": "0"
+}

--- a/tests/xml/noMatchWarning/no_match_allow_input.xml
+++ b/tests/xml/noMatchWarning/no_match_allow_input.xml
@@ -1,0 +1,5 @@
+<Test>
+    <Node>
+        <Meow><GUID>1</GUID></Meow>
+    </Node>
+</Test>

--- a/tests/xml/noMatchWarning/no_match_allow_patch.xml
+++ b/tests/xml/noMatchWarning/no_match_allow_patch.xml
@@ -1,0 +1,5 @@
+<ModOps>
+<ModOp Type="addNextSibling" Path="/Test/Node/Meow[GUID='2']" AllowNoMatch="1">
+    <Meow><GUID>3</GUID></Meow>
+</ModOp>
+</ModOps>

--- a/tests/xml/noMatchWarning/no_match_warning.json
+++ b/tests/xml/noMatchWarning/no_match_warning.json
@@ -1,0 +1,7 @@
+{
+    "name": "Add No Match",
+    "expected": [
+        "/Test/Node/Meow[GUID='1']"
+    ],
+    "issuesExpected": "1"
+}

--- a/tests/xml/noMatchWarning/no_match_warning_input.xml
+++ b/tests/xml/noMatchWarning/no_match_warning_input.xml
@@ -1,0 +1,5 @@
+<Test>
+    <Node>
+        <Meow><GUID>1</GUID></Meow>
+    </Node>
+</Test>

--- a/tests/xml/noMatchWarning/no_match_warning_patch.xml
+++ b/tests/xml/noMatchWarning/no_match_warning_patch.xml
@@ -1,0 +1,5 @@
+<ModOps>
+<ModOp Type="addNextSibling" Path="/Test/Node/Meow[GUID='2']">
+    <Meow><GUID>3</GUID></Meow>
+</ModOp>
+</ModOps>

--- a/tests/xml/runner.h
+++ b/tests/xml/runner.h
@@ -1,4 +1,6 @@
 #include "pugixml.hpp"
+#include "spdlog/sinks/ostream_sink.h"
+#include "spdlog/spdlog.h"
 
 #include "xml_operations.h"
 
@@ -14,6 +16,13 @@ class TestRunner
 {
 public:
     TestRunner(std::string_view mod_path, std::string_view input, std::string_view patch) {
+        {
+            auto sink = std::make_shared<spdlog::sinks::ostream_sink_st>(test_log_);
+            auto test_logger = std::make_shared<spdlog::logger>("test_logger", sink);
+            test_logger->set_pattern("[%l] %v");
+            test_logger->set_level(spdlog::level::info);
+            spdlog::set_default_logger(test_logger);
+        }
         {
             xml_operations_ = XmlOperation::GetXmlOperationsFromFile(patch, "", input, mod_path);
         }
@@ -42,7 +51,6 @@ public:
         return exists;
     }
 
-
     std::string DumpXml() {
         std::stringstream ss;
         input_doc_->print(ss, "   ");
@@ -50,8 +58,26 @@ public:
         return buf;
     }
 
-    ~TestRunner() = default;
+    bool HasIssues() {
+        auto log_content = test_log_.str();
+        
+        if (log_content.find("[warning]") != std::string::npos || 
+            log_content.find("[error]") != std::string::npos) {
+            return true;
+        }
+
+        return false;
+    }
+
+    std::string DumpLog() {
+        return test_log_.str();
+    }
+
+    ~TestRunner() {
+        spdlog::drop("test_logger");
+    }
 private:
     std::vector<XmlOperation> xml_operations_;
     std::shared_ptr<pugi::xml_document> input_doc_ = nullptr;
+    std::ostringstream test_log_;
 };

--- a/tests/xml/runner.h
+++ b/tests/xml/runner.h
@@ -13,9 +13,9 @@
 class TestRunner
 {
 public:
-    TestRunner(std::string_view mod_path, std::string_view input, std::string_view patch) {
+    TestRunner(std::string_view mod_base_path, std::string_view input, std::string_view patch) {
         {
-            xml_operations_ = XmlOperation::GetXmlOperationsFromFile(patch, "", input, mod_path);
+            xml_operations_ = XmlOperation::GetXmlOperationsFromFile(fs::absolute(patch), "", input, fs::absolute(mod_base_path));
         }
         {
             input_doc_ = std::make_shared<pugi::xml_document>();

--- a/tests/xml/skip/skip_include.json
+++ b/tests/xml/skip/skip_include.json
@@ -1,0 +1,6 @@
+{
+    "name": "Skip Include",
+    "expected": [
+        "/Test/Node[Meow='1']"
+    ]
+}

--- a/tests/xml/skip/skip_include.xml
+++ b/tests/xml/skip/skip_include.xml
@@ -1,0 +1,3 @@
+<ModOps>
+<ModOp Type="remove" Path="/Test/Node/Meow" />
+</ModOps>

--- a/tests/xml/skip/skip_include_input.xml
+++ b/tests/xml/skip/skip_include_input.xml
@@ -1,0 +1,5 @@
+<Test>
+    <Node>
+        <Meow>1</Meow>
+    </Node>
+</Test>

--- a/tests/xml/skip/skip_include_patch.xml
+++ b/tests/xml/skip/skip_include_patch.xml
@@ -1,0 +1,3 @@
+<ModOps>
+    <Include File="skip_include.xml" Skip="1" />
+</ModOps>

--- a/tests/xml/xpath_or/xpath_or.json
+++ b/tests/xml/xpath_or/xpath_or.json
@@ -1,0 +1,7 @@
+{
+    "name": "XPath | Behavior",
+    "expected": [
+        "!/Test/Asset/Values[Standard/GUID='5']/Meow",
+        "/Test/Asset/Values[Standard/GUID='4']/Meow"
+    ]
+}

--- a/tests/xml/xpath_or/xpath_or_input.xml
+++ b/tests/xml/xpath_or/xpath_or_input.xml
@@ -1,0 +1,18 @@
+<Test>
+    <Asset>
+        <Values>
+            <Standard>
+                <GUID>5</GUID>
+            </Standard>
+            <Meow>5</Meow>
+        </Values>
+    </Asset>
+    <Asset>
+        <Values>
+            <Standard>
+                <GUID>4</GUID>
+            </Standard>
+            <Meow>4</Meow>
+        </Values>
+    </Asset>
+</Test>

--- a/tests/xml/xpath_or/xpath_or_patch.xml
+++ b/tests/xml/xpath_or/xpath_or_patch.xml
@@ -1,0 +1,3 @@
+<ModOps>
+<ModOp Type="remove" GUID="7" Path="/Values/Meow | //Asset/Values[Standard/GUID='5']/Meow" />
+</ModOps>


### PR DESCRIPTION
ModOps will only execute on match.
`!` can be used to only execute on no match.

Closes #28 